### PR TITLE
refactor: Remove raw data, refine detailed exercise view, and improve…

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,20 +112,18 @@
                     </select>
                 </div>
                 <div id="multi-exercise-select-group-analysis" style="display: none;">
-                    <label for="multi-exercise-select-analysis">Compare Exercises (select multiple):</label>
+                    <label for="multi-exercise-select-analysis">Compare Exercises:</label>
                     <select id="multi-exercise-select-analysis" multiple size="5">
                         <!-- Options populated by JS -->
                     </select>
+                    <small class="form-hint">Hold Ctrl (Cmd on Mac) to select multiple items, or Shift to select a range.</small>
                     <button id="generate-volume-comparison-btn" class="button-primary">Generate Chart</button>
                 </div>
             </div>
             <div id="progress-chart-container" style="display: none;">
                 <canvas id="progressChart"></canvas>
             </div>
-            <div id="raw-data-container">
-                <h4>Raw Data:</h4>
-                <pre id="raw-data-output"></pre>
-            </div>
+            <!-- Raw data container removed -->
         </section>
     </main>
     <footer>

--- a/style.css
+++ b/style.css
@@ -579,3 +579,11 @@ ul.styled-list { /* Remove default list styling if ul is used */
 #generate-volume-comparison-btn {
     margin-top: 10px;
 }
+
+.form-hint {
+    display: block;
+    font-size: 0.85em;
+    color: var(--text-muted);
+    margin-top: 5px;
+    margin-bottom: 10px; /* Add some space before button if hint is long */
+}


### PR DESCRIPTION
… analysis UX

- Removed all raw data `<pre>` tag displays from the Analysis section to clean up the UI.
- Refined the Detailed Exercise View:
  - The "Previous Performance" section now only displays sets from the single most recent session where the exercise was performed.
  - The 1RM calculator dropdown and the mini-progress chart in this view continue to use all historical data for that exercise type for comprehensive analysis.
  - Ensured navigation to the set tracker from this view correctly maintains context for adding sets to the current session.
- Fixed/Improved Analysis Tab Exercise Comparison:
  - Added an instructional hint below the multi-select dropdown to clarify how to select multiple exercises (Ctrl/Cmd+Click or Shift+Click), addressing usability for this standard HTML element.